### PR TITLE
Rename deprecated sympy printing class and submodules

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,7 +47,7 @@ Code generation system
     :members:
     :special-members:
 
-.. autoclass:: CCodePrinter
+.. autoclass:: C89CodePrinter
     :members:
     :special-members:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -10,6 +10,6 @@ definitions can be given to the :py:func:`optimize` function, then a
 mathematically-equivalent list of tensor definitions will be returned, possibly
 incurring much less arithmetic cost.   For any iterable of tensor definitions,
 whether from the gristmill optimizer or not, the code printers
-:py:class:`FortranPrinter`, :py:class:`CCodePrinter`, and
+:py:class:`FortranPrinter`, :py:class:`C89CodePrinter`, and
 :py:class:`EinsumPrinter` can be used to generate code automatically.  The exact
 form of the generated code is very tunable.

--- a/gristmill/__init__.py
+++ b/gristmill/__init__.py
@@ -4,7 +4,7 @@ Public names are going to be imported here.
 """
 
 from .generate import (
-    BasePrinter, NaiveCodePrinter, CCodePrinter, FortranPrinter,
+    BasePrinter, NaiveCodePrinter, C89CodePrinter, FortranPrinter,
     EinsumPrinter, mangle_base
 )
 from .optimize import optimize, verify_eval_seq, ContrStrat, RepeatedTermsStrat
@@ -21,7 +21,7 @@ __all__ = [
     'BasePrinter',
     'mangle_base',
     'NaiveCodePrinter',
-    'CCodePrinter',
+    'C89CodePrinter',
     'FortranPrinter',
     'EinsumPrinter'
 ]

--- a/gristmill/generate.py
+++ b/gristmill/generate.py
@@ -11,8 +11,8 @@ from drudge.term import try_resolve_range
 from sympy import (
     Expr, Mul, Pow, Integer, Rational, Add, Indexed, IndexedBase, Symbol
 )
-from sympy.printing.ccode import CCodePrinter
-from sympy.printing.fcode import FCodePrinter
+from sympy.printing.c import C89CodePrinter
+from sympy.printing.fortran import FCodePrinter
 from sympy.printing.printer import Printer
 from sympy.printing.python import PythonPrinter
 
@@ -1143,7 +1143,7 @@ class CPrinter(NaiveCodePrinter):
         """
 
         super().__init__(
-            CCodePrinter(), print_indexed_cb=print_indexed_cb,
+            C89CodePrinter(), print_indexed_cb=print_indexed_cb,
             line_cont='\\', stmt_end=';', **kwargs
         )
 

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     packages=find_packages(),
     ext_modules=[parenth],
     package_data={'gristmill': ['templates/*']},
-    install_requires=['drudge', 'Jinja2', 'sympy', 'numpy', 'networkx>=2.0']
+    install_requires=['drudge', 'Jinja2', 'sympy>=1.7', 'numpy', 'networkx>=2.0']
 )


### PR DESCRIPTION
In SymPy 1.7 `CCodePrinter` was deprecated, as were `sympy.printing.ccode` and `sympy.printing.fcode`. This PR updates the class and submodule names so as to keep Gristmill up-to-date with SymPy.